### PR TITLE
async await in getInitialProps

### DIFF
--- a/components/ensureSignedIn.js
+++ b/components/ensureSignedIn.js
@@ -9,9 +9,9 @@ import React from 'react'
 
 const ensureSignedIn = Page => {
   return class EnsureSignedIn extends React.Component {
-    static getInitialProps (context) {
+    static async getInitialProps (context) {
       // If the page has a prop fetcher invoke it
-      return Page.getInitialProps ? Page.getInitialProps(context) : {}
+      return Page.getInitialProps ? await Page.getInitialProps(context) : {}
     }
 
     constructor (props) {

--- a/components/injectEnvironmentVar.js
+++ b/components/injectEnvironmentVar.js
@@ -21,9 +21,9 @@ const injectEnvironmentVar = varName => Page => {
   }
 
   return class InjectEnvironmentVar extends React.Component {
-    static getInitialProps (context) {
+    static async getInitialProps (context) {
       // Get the page's own initial props
-      const initialProps = Page.getInitialProps ? Page.getInitialProps(context) : {}
+      const initialProps = Page.getInitialProps ? await Page.getInitialProps(context) : {}
       // Dig the specified environment variables up from the
       // appropriate sources
       const env = process.browser ? global.__next_env : process.env

--- a/components/injectSession.js
+++ b/components/injectSession.js
@@ -25,9 +25,9 @@ const injectSession = Page => {
       this.state = {}
     }
 
-    static getInitialProps (context) {
+    static async getInitialProps (context) {
       // Get the page's own initial props
-      const initialProps = Page.getInitialProps ? Page.getInitialProps(context) : {}
+      const initialProps = Page.getInitialProps ? await Page.getInitialProps(context) : {}
 
       // Dig the session out of localstorage (on client) or the request (on
       // server)

--- a/components/wrapWithLayout.js
+++ b/components/wrapWithLayout.js
@@ -5,9 +5,9 @@ import Menu from './Menu'
 
 const wrapWithLayout = Page => {
   return class WrapWithLayout extends React.Component {
-    static getInitialProps (context) {
+    static async getInitialProps (context) {
       return Page.getInitialProps
-        ? Page.getInitialProps(context)
+        ? await Page.getInitialProps(context)
         : {}
     }
 


### PR DESCRIPTION
What this PR fixes? 

If there is some AJAX call made in the server-rendered pages, the promise remains pending while the same page is wrapped in HOCs ultimately leading to the response data being unavailable. 

So I have made `getInitialProps` in HOCs asynchronous. Hope it helps.

Also, thanks for this great project! 